### PR TITLE
The fs sensor now rounds the resulting number with 2 digits

### DIFF
--- a/indicator-sysmonitor
+++ b/indicator-sysmonitor
@@ -360,7 +360,7 @@ class StatusFetcher(Thread):
 
         for unit in B_UNITS:
             if bytes_ < 1024:
-                return "{} {}".format(bytes_, unit)
+                return "{} {}".format(round(bytes_,2), unit)
             bytes_ /= 1024
 
     def run(self):


### PR DESCRIPTION
On my system the free space on hd had many digits after the decimal point.
![before](https://cloud.githubusercontent.com/assets/61795/4100292/da64b6d4-308d-11e4-9617-27d1b0a27e48.png)

Now it shows only two digits.
![after](https://cloud.githubusercontent.com/assets/61795/4100291/da638e3a-308d-11e4-8983-960203e3451d.png)
