### PR TITLE
Use MemAvailable in /proc/meminfo for memory available to user.

### DIFF
--- a/sensors.py
+++ b/sensors.py
@@ -390,12 +390,9 @@ class MemSensor(BaseSensor):
         """It gets the total memory info and return the used in percent."""
         with open('/proc/meminfo') as meminfo:
             total = SensorManager.digit_regex.findall(meminfo.readline()).pop()
-            free = SensorManager.digit_regex.findall(meminfo.readline()).pop()
             meminfo.readline()
-            cached = SensorManager.digit_regex.findall(
-                meminfo.readline()).pop()
-            free = int(free) + int(cached)
-            return 100 - 100 * free / float(total)
+            available = SensorManager.digit_regex.findall(meminfo.readline()).pop()
+            return 100 - 100 * int(available) / float(total)
 
 
 class NetSensor(BaseSensor):

--- a/sensors.py
+++ b/sensors.py
@@ -18,6 +18,7 @@ import copy
 import logging
 import re
 import os
+import platform
 from gettext import gettext as _
 
 import psutil as ps
@@ -390,9 +391,22 @@ class MemSensor(BaseSensor):
         """It gets the total memory info and return the used in percent."""
         with open('/proc/meminfo') as meminfo:
             total = SensorManager.digit_regex.findall(meminfo.readline()).pop()
-            meminfo.readline()
-            available = SensorManager.digit_regex.findall(meminfo.readline()).pop()
-            return 100 - 100 * int(available) / float(total)
+            release = re.split('\.', platform.release())
+            major_version = int(release[0])
+            minor_version = int(release[1])
+            if (minor_version >= 16 and major_version >= 3):
+                meminfo.readline()
+                available = SensorManager.digit_regex.findall(
+                    meminfo.readline()).pop()
+                return 100 - 100 * int(available) / float(total)
+            else:
+                free = SensorManager.digit_regex.findall(
+                    meminfo.readline()).pop()
+                meminfo.readline()
+                cached = SensorManager.digit_regex.findall(
+                    meminfo.readline()).pop()
+                free = int(free) + int(cached)
+                return 100 - 100 * free / float(total)
 
 
 class NetSensor(BaseSensor):


### PR DESCRIPTION
MemAvailable was recently introduced into the Linux kernel to simplify
estimating the amount of "memory available for starting new
applications, without swapping." This way user applications no longer
have to know how the kernel internally handles memory.

The previous way of calculating available memory produced erroneously large usages on Ubuntu 15.04. Ex, it indicated 42% usage when 36% was correct. (And this was only after I adjusted the code to skip the new MemAvailable entry - otherwise the wrong info is read from meminfo.) Using MemAvailable fixes the problem and agrees roughly with system monitor.

I am not sure which Linux kernel first introduced MemAvailable, but [here is the relevant commit](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773).