### PR TITLE
fixed the bug#23

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ https://launchpad.net/indicator-sysmonitor
 
 Current fork maintainer: fossfreedom <foss.freedom@gmail.com>
 
+v0.6.3: SteveGuo <steveguo@outlook.com>
+https://github.com/SteveGuo
+
 ----
 
-Installation - v0.6.2 stable
+Installation - v0.6.3 stable
 
 on Ubuntu and derivatives - manual installation
 
@@ -39,6 +42,7 @@ To install via PPA:
 
 Changelog
  
+ - v0.6.3 - fixed the bug when display multiple CPU cores it always display the later ones as 0%
  - v0.6.2 - bug fix to stop crash for custom sensors
  - v0.6.1 - fix the debian packaging
  - v0.6 - stable release - reworked to be easier to maintain

--- a/preferences.py
+++ b/preferences.py
@@ -21,7 +21,7 @@ from sensors import SensorManager
 from sensors import ISMError
 
 
-VERSION = '0.6.2~stable'
+VERSION = '0.6.3~stable'
 
 
 def raise_dialog(parent, flags, type_, buttons, msg, title):


### PR DESCRIPTION
{cpu1} displays always 0% when set to display two cpu cores like this:
{cpu0}{cpu1}https://github.com/fossfreedom/indicator-sysmonitor/issues/23