### PR TITLE
Attempt to comply with psutil v2 API.

### DIFF
--- a/sensors.py
+++ b/sensors.py
@@ -22,6 +22,9 @@ from gettext import gettext as _
 
 import psutil as ps
 
+ps_v1_api = int(ps.__version__.split('.')[0]) <= 1
+
+
 B_UNITS = ['', 'KB', 'MB', 'GB', 'TB']
 cpu_load = []
 
@@ -332,6 +335,10 @@ class CPUSensor(BaseSensor):
     desc = _('Average CPU usage')
     cpus = re.compile("\Acpu\d*\Z")
     last = None
+    if ps_v1_api:
+        cpu_count = ps.NUM_CPUS
+    else:
+        cpu_count = ps.cpu_count()
 
     def check(self, sensor):
         if self.cpus.match(sensor):
@@ -340,9 +347,9 @@ class CPUSensor(BaseSensor):
             else:
                 nber = int(sensor[3:]) if len(sensor) > 3 else 999
 
-            if nber >= ps.cpu_count():
+            if nber >= self.cpu_count:
                 print(sensor)
-                print(ps.cpu_count())
+                print(self.cpu_count)
                 print(len(sensor))
                 raise ISMError(_("Invalid number of CPUs."))
 
@@ -365,7 +372,7 @@ class CPUSensor(BaseSensor):
         for i in cpu_load:
             r += i
 
-        r /= ps.cpu_count()
+        r /= self.cpu_count
 
         return r
 

--- a/sensors.py
+++ b/sensors.py
@@ -340,9 +340,9 @@ class CPUSensor(BaseSensor):
             else:
                 nber = int(sensor[3:]) if len(sensor) > 3 else 999
 
-            if nber >= ps.NUM_CPUS:
+            if nber >= ps.cpu_count():
                 print(sensor)
-                print(ps.NUM_CPUS)
+                print(ps.cpu_count())
                 print(len(sensor))
                 raise ISMError(_("Invalid number of CPUs."))
 
@@ -365,7 +365,7 @@ class CPUSensor(BaseSensor):
         for i in cpu_load:
             r += i
 
-        r /= ps.NUM_CPUS
+        r /= ps.cpu_count()
 
         return r
 


### PR DESCRIPTION
This commit adds support for the psutil v2 and v3 API, where some module constants were converted to functions. In v3 it seems backwards compatibility with v1 API was dropped, so I work around this by adding a simple library version check. My current change assumes the number of CPUs is constant (until the app is restarted).

For more detail, see:
http://grodola.blogspot.com/2014/01/psutil-20-porting.html
