### PR TITLE
fix the problem that netspeed size change

### DIFF
--- a/sensors.py
+++ b/sensors.py
@@ -35,7 +35,7 @@ def bytes_to_human(bytes_):
         unit += 1
         bytes_ /= 1024
 
-    return '{}{}'.format(int(bytes_), B_UNITS[unit])
+    return '{:4d}{}'.format(int(bytes_), B_UNITS[unit])
 
 
 class ISMError(Exception):

--- a/sensors.py
+++ b/sensors.py
@@ -35,7 +35,7 @@ def bytes_to_human(bytes_):
         unit += 1
         bytes_ /= 1024
 
-    return '{:4d}{}'.format(int(bytes_), B_UNITS[unit])
+    return '{:4d}{:2}'.format(int(bytes_), B_UNITS[unit])
 
 
 class ISMError(Exception):


### PR DESCRIPTION
Force the NetSonsor output size to 4, so that we don't need to change the display order of the indicator.
And we think we should provide an option for people to set the size they want.
