### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Offers the possibility to run your own command and display its output.
 
 ----
 
-##Custom scripts
+## Custom scripts
 
 Create your own scripts (for example in bash).  Give the script execute permission (chmod +x scriptname)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
