### PR TITLE
Improve Makefile (multiple fixes)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,34 @@
-DESTDIR=/usr
+PREFIX=/usr
 BUDGIELIB=lib/budgie-desktop/plugins/budgiesysmonitor
 
 all:
 
 install:
-	mkdir -p ${DESTDIR}/lib/indicator-sysmonitor
-	cp indicator-sysmonitor ${DESTDIR}/lib/indicator-sysmonitor
-	cp preferences.py ${DESTDIR}/lib/indicator-sysmonitor
-	cp sensors.py ${DESTDIR}/lib/indicator-sysmonitor
-	cp preferences.ui ${DESTDIR}/lib/indicator-sysmonitor
-	mkdir -p ${DESTDIR}/bin/
-	ln -s ${DESTDIR}/lib/indicator-sysmonitor/indicator-sysmonitor ${DESTDIR}/bin/indicator-sysmonitor 
-	mkdir -p ${DESTDIR}/share/applications
-	cp indicator-sysmonitor.desktop ${DESTDIR}/share/applications/
+	mkdir -p $(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor
+	cp indicator-sysmonitor $(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor
+	cp preferences.py $(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor
+	cp sensors.py $(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor
+	cp preferences.ui $(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor
+	mkdir -p $(DESTDIR)$(PREFIX)/bin/
+	ln -s ../lib/indicator-sysmonitor/indicator-sysmonitor $(DESTDIR)$(PREFIX)/bin/indicator-sysmonitor 
+	mkdir -p $(DESTDIR)$(PREFIX)/share/applications
+	cp indicator-sysmonitor.desktop $(DESTDIR)$(PREFIX)/share/applications/
 	
 installbudgie:
-	mkdir -p ${DESTDIR}/${BUDGIELIB}
-	cp budgiesysmonitor.py ${DESTDIR}/${BUDGIELIB}
-	cp preferences.py ${DESTDIR}/${BUDGIELIB}
-	cp sensors.py ${DESTDIR}/${BUDGIELIB}
-	cp preferences.ui ${DESTDIR}/${BUDGIELIB}
-	cp BudgieSysMonitor.plugin ${DESTDIR}/${BUDGIELIB} 
+	mkdir -p $(DESTDIR)$(PREFIX)/$(BUDGIELIB)
+	cp budgiesysmonitor.py $(DESTDIR)$(PREFIX)/$(BUDGIELIB)
+	cp preferences.py $(DESTDIR)$(PREFIX)/$(BUDGIELIB)
+	cp sensors.py $(DESTDIR)$(PREFIX)/$(BUDGIELIB)
+	cp preferences.ui $(DESTDIR)$(PREFIX)/$(BUDGIELIB)
+	cp BudgieSysMonitor.plugin $(DESTDIR)$(PREFIX)/$(BUDGIELIB) 
 	
 clean:
 	rm -rf ../*.xz ../*.deb ../*.tar.gz ../*.changes ../*.dsc ../*.upload ../*.build ../*.cdbs-config_list
 	
 uninstall:
-	rm -rf ${DESTDIR}/lib/indicator-sysmonitor
-	rm -f ${DESTDIR}/bin/indicator-sysmonitor
-	rm -f ${DESTDIR}/share/applications/indicator-sysmonitor.desktop
-	rm -rf ${DESTDIR}/${BUDGIELIB}
+	rm -rf $(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor
+	rm -f $(DESTDIR)$(PREFIX)/bin/indicator-sysmonitor
+	rm -f $(DESTDIR)$(PREFIX)/share/applications/indicator-sysmonitor.desktop
+	rm -rf $(DESTDIR)$(PREFIX)/$(BUDGIELIB)
 
 .PHONY: clean install all

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 	mkdir -p "$(DESTDIR)$(PREFIX)/bin/"
 	ln -s ../lib/indicator-sysmonitor/indicator-sysmonitor "$(DESTDIR)$(PREFIX)/bin/indicator-sysmonitor"
 	mkdir -p "$(DESTDIR)$(PREFIX)/share/applications"
-	cp indicator-sysmonitor.desktop $(DESTDIR)$(PREFIX)/share/applications/"
+	cp indicator-sysmonitor.desktop "$(DESTDIR)$(PREFIX)/share/applications/"
 	
 installbudgie:
 	mkdir -p "$(DESTDIR)$(PREFIX)/$(BUDGIELIB)"

--- a/Makefile
+++ b/Makefile
@@ -4,31 +4,31 @@ BUDGIELIB=lib/budgie-desktop/plugins/budgiesysmonitor
 all:
 
 install:
-	mkdir -p $(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor
-	cp indicator-sysmonitor $(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor
-	cp preferences.py $(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor
-	cp sensors.py $(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor
-	cp preferences.ui $(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor
-	mkdir -p $(DESTDIR)$(PREFIX)/bin/
-	ln -s ../lib/indicator-sysmonitor/indicator-sysmonitor $(DESTDIR)$(PREFIX)/bin/indicator-sysmonitor 
-	mkdir -p $(DESTDIR)$(PREFIX)/share/applications
-	cp indicator-sysmonitor.desktop $(DESTDIR)$(PREFIX)/share/applications/
+	mkdir -p "$(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor"
+	cp indicator-sysmonitor "$(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor"
+	cp preferences.py "$(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor"
+	cp sensors.py "$(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor"
+	cp preferences.ui "$(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor"
+	mkdir -p "$(DESTDIR)$(PREFIX)/bin/"
+	ln -s ../lib/indicator-sysmonitor/indicator-sysmonitor "$(DESTDIR)$(PREFIX)/bin/indicator-sysmonitor"
+	mkdir -p "$(DESTDIR)$(PREFIX)/share/applications"
+	cp indicator-sysmonitor.desktop $(DESTDIR)$(PREFIX)/share/applications/"
 	
 installbudgie:
-	mkdir -p $(DESTDIR)$(PREFIX)/$(BUDGIELIB)
-	cp budgiesysmonitor.py $(DESTDIR)$(PREFIX)/$(BUDGIELIB)
-	cp preferences.py $(DESTDIR)$(PREFIX)/$(BUDGIELIB)
-	cp sensors.py $(DESTDIR)$(PREFIX)/$(BUDGIELIB)
-	cp preferences.ui $(DESTDIR)$(PREFIX)/$(BUDGIELIB)
-	cp BudgieSysMonitor.plugin $(DESTDIR)$(PREFIX)/$(BUDGIELIB) 
+	mkdir -p "$(DESTDIR)$(PREFIX)/$(BUDGIELIB)"
+	cp budgiesysmonitor.py "$(DESTDIR)$(PREFIX)/$(BUDGIELIB)"
+	cp preferences.py "$(DESTDIR)$(PREFIX)/$(BUDGIELIB)"
+	cp sensors.py "$(DESTDIR)$(PREFIX)/$(BUDGIELIB)"
+	cp preferences.ui "$(DESTDIR)$(PREFIX)/$(BUDGIELIB)"
+	cp BudgieSysMonitor.plugin "$(DESTDIR)$(PREFIX)/$(BUDGIELIB)"
 	
 clean:
 	rm -rf ../*.xz ../*.deb ../*.tar.gz ../*.changes ../*.dsc ../*.upload ../*.build ../*.cdbs-config_list
 	
 uninstall:
-	rm -rf $(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor
-	rm -f $(DESTDIR)$(PREFIX)/bin/indicator-sysmonitor
-	rm -f $(DESTDIR)$(PREFIX)/share/applications/indicator-sysmonitor.desktop
-	rm -rf $(DESTDIR)$(PREFIX)/$(BUDGIELIB)
+	rm -rf "$(DESTDIR)$(PREFIX)/lib/indicator-sysmonitor"
+	rm -f "$(DESTDIR)$(PREFIX)/bin/indicator-sysmonitor"
+	rm -f "$(DESTDIR)$(PREFIX)/share/applications/indicator-sysmonitor.desktop"
+	rm -rf "$(DESTDIR)$(PREFIX)/$(BUDGIELIB)"
 
 .PHONY: clean install all


### PR DESCRIPTION
DESTDIR is usually set from outside (eg. when packaging applications) to build inside a destination, this replaces DESTDIR with PREFIX while preserving the DESTDIR usage on the paths, allowing for external definition without unexpected behavior.

This patch also replaces the absolute link in the install section with a relative link, thus making the files more portable.