### PR TITLE
Add float for intervals + Add NetSpeed Compact and TotalNetSpeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,106 +1,11 @@
-![indicator-sysmonitor](https://user-images.githubusercontent.com/9158844/37069705-90f272a2-21c5-11e8-806f-92b20cbf47ae.png)
+Whats NEW  :  
+\* *The following string are added:*
 
-\* _Use following string to use custom preview that is shown above. (Proprietary Nvidia driver needed, must be running)_:
-
-    CPU {cpu}  {cputemp}   |  GPU {nvgpu}  {nvgputemp}  |  MEM {mem}  |  SWAP {swap}
-
-Indicator-SysMonitor - v0.8.3
-===================
-An Application Indicator showing cpu temperature, memory, network speed, cpu usage, public IP address and internet connection status .
-
-Works with Unity, Xubuntu, Gnome-Shell + app-indicator extension together with any other desktop environments that support AppIndicators.
-
-Also works with the Budgie-Desktop
-
-Offers the possibility to run your own command and display its output.
-
-----
-
-## Custom scripts
-
-Create your own scripts (for example in bash).  Give the script execute permission (chmod +x scriptname)
-
-A script must output one line of text - e.g. using "echo" in bash
-
-The indicator can change the icon being displayed by recognising the output of a sensor "USE_ICON:full_path_to_.svg"
-
-## Set the display order of the indicator
-
-To force the indicator to appear on the left-side of all indicators you must use a override file as described here:
-
- - http://askubuntu.com/questions/26114/is-it-possible-to-change-the-order-of-icons-in-the-indicator-applet
-
-----
-
-Installation - Budgie-Desktop:
-
-On budgie-desktop based installation  - manual installation
-
-    sudo apt-get install python3-psutil curl git
-    git clone https://github.com/fossfreedom/indicator-sysmonitor.git
-    cd indicator-sysmonitor
-    sudo make installbudgie
-    budgie-panel --replace &
+    NetCompact {netcomp} | totalnet {totalnet}
     
-    Then use Raven to add the "Panel Sys Monitor" applet
+In this version you can also set Interval time in milliseconds like 1.5sec etc...  
 
-Installation - App Indicator based desktops:
+Below is the Preview of new strings in Action on Budgie:
+![Budgie Screenshot](https://user-images.githubusercontent.com/41370460/98227405-4ab9dd80-1f7d-11eb-9601-cc3e66c8718c.png)
 
-On Ubuntu and derivatives - manual installation
-
-
-    sudo apt-get install python3-psutil curl git gir1.2-appindicator3-0.1
-    git clone https://github.com/fossfreedom/indicator-sysmonitor.git
-    cd indicator-sysmonitor
-    sudo make install
-    nohup indicator-sysmonitor &
-    
-To remove:
-
-    cd indicator-sysmonitor
-    sudo make uninstall
-        
-To install the AppIndicator via PPA:
-
-    sudo add-apt-repository ppa:fossfreedom/indicator-sysmonitor
-    sudo apt-get update
-    sudo apt-get install indicator-sysmonitor
-    
-    Search in the dash for "indicator-sysmonitor" to run
-
-To install the Budgie Applet via PPA:
-
-    open budgie-welcome - Install Software - Budgie Applets
-
-Changelog:
- 
- - v0.8.3 - Rework fetch thread, README updates
- - v0.8.2 - fix budgie-desktop crash and release debian package
- - v0.8.1 - development - support budgie-desktop
- - v0.8.0 - development - new sensor - cputemp, ability to use and change icons via a custom script
- - v0.7.1 - bug fix to allow non-ubuntu kernels to be used
- - v0.7.0 - new sensors - publicip and upordown.
- - v0.6.3 - fixed the bug when display multiple CPU cores it always display the later ones as 0%
- - v0.6.2 - bug fix to stop crash for custom sensors
- - v0.6.1 - fix the debian packaging
- - v0.6 - stable release - reworked to be easier to maintain
- - v0.5 - GTK3 & Python3 based including bug-fix to display errors on using Test button
-     together with fixing crash reports when incorrect sensor values used
- - v0.4.6 - bug fixes for battery indicator and for spurious overwrite when adding new sensor
- - v0.4.5 - removed indicator icon since not needed
- - v0.4.4 - fix dependencies and corrected shown indicator icon
- - v0.4.3 - fork from original author
- 
-Credits:
- 
- - [24](https://github.com/fossfreedom/indicator-sysmonitor/pull/24) & [25](https://github.com/fossfreedom/indicator-sysmonitor/pull/25) SteveGuo <steveguo@outlook.com> https://github.com/SteveGuo
- - [19](https://github.com/fossfreedom/indicator-sysmonitor/pull/19) & [37](https://github.com/fossfreedom/indicator-sysmonitor/pull/37) CPU & meminfo bug fixes Jesse Johnson https://github.com/holocronweaver
-
-----
-
-Original Author: Alex Eftimie <alex@rosedu.org>
-https://launchpad.net/indicator-sysmonitor
-
-Current fork maintainer: fossfreedom <foss.freedom@gmail.com>
-
-----
+First one is Output of {netcomp} & other is the output of {totalnet}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 ![indicator-sysmonitor](https://user-images.githubusercontent.com/9158844/37069705-90f272a2-21c5-11e8-806f-92b20cbf47ae.png)
+![image](https://user-images.githubusercontent.com/41370460/98230824-9cfcfd80-1f81-11eb-9a68-2ac6e1c8adb9.png)
+
 
 \* _Use following string to use custom preview that is shown above. (Proprietary Nvidia driver needed, must be running)_:
 
-    CPU {cpu}  {cputemp}   |  GPU {nvgpu}  {nvgputemp}  |  MEM {mem}  |  SWAP {swap}
+    CPU {cpu}  {cputemp}   |  GPU {nvgpu}  {nvgputemp}  |  MEM {mem}  |  SWAP {swap}  |  Net Speed Compact {netcomp}  |  Total Net Speed {totalnet}
 
 Indicator-SysMonitor - v0.8.3
 ===================

--- a/README.md
+++ b/README.md
@@ -1,11 +1,106 @@
-Whats NEW  :  
-\* *The following string are added:*
+![indicator-sysmonitor](https://user-images.githubusercontent.com/9158844/37069705-90f272a2-21c5-11e8-806f-92b20cbf47ae.png)
 
-    NetCompact {netcomp} | totalnet {totalnet}
+\* _Use following string to use custom preview that is shown above. (Proprietary Nvidia driver needed, must be running)_:
+
+    CPU {cpu}  {cputemp}   |  GPU {nvgpu}  {nvgputemp}  |  MEM {mem}  |  SWAP {swap}
+
+Indicator-SysMonitor - v0.8.3
+===================
+An Application Indicator showing cpu temperature, memory, network speed, cpu usage, public IP address and internet connection status .
+
+Works with Unity, Xubuntu, Gnome-Shell + app-indicator extension together with any other desktop environments that support AppIndicators.
+
+Also works with the Budgie-Desktop
+
+Offers the possibility to run your own command and display its output.
+
+----
+
+## Custom scripts
+
+Create your own scripts (for example in bash).  Give the script execute permission (chmod +x scriptname)
+
+A script must output one line of text - e.g. using "echo" in bash
+
+The indicator can change the icon being displayed by recognising the output of a sensor "USE_ICON:full_path_to_.svg"
+
+## Set the display order of the indicator
+
+To force the indicator to appear on the left-side of all indicators you must use a override file as described here:
+
+ - http://askubuntu.com/questions/26114/is-it-possible-to-change-the-order-of-icons-in-the-indicator-applet
+
+----
+
+Installation - Budgie-Desktop:
+
+On budgie-desktop based installation  - manual installation
+
+    sudo apt-get install python3-psutil curl git
+    git clone https://github.com/fossfreedom/indicator-sysmonitor.git
+    cd indicator-sysmonitor
+    sudo make installbudgie
+    budgie-panel --replace &
     
-In this version you can also set Interval time in milliseconds like 1.5sec etc...  
+    Then use Raven to add the "Panel Sys Monitor" applet
 
-Below is the Preview of new strings in Action on Budgie:
-![Budgie Screenshot](https://user-images.githubusercontent.com/41370460/98227405-4ab9dd80-1f7d-11eb-9601-cc3e66c8718c.png)
+Installation - App Indicator based desktops:
 
-First one is Output of {netcomp} & other is the output of {totalnet}
+On Ubuntu and derivatives - manual installation
+
+
+    sudo apt-get install python3-psutil curl git gir1.2-appindicator3-0.1
+    git clone https://github.com/fossfreedom/indicator-sysmonitor.git
+    cd indicator-sysmonitor
+    sudo make install
+    nohup indicator-sysmonitor &
+    
+To remove:
+
+    cd indicator-sysmonitor
+    sudo make uninstall
+        
+To install the AppIndicator via PPA:
+
+    sudo add-apt-repository ppa:fossfreedom/indicator-sysmonitor
+    sudo apt-get update
+    sudo apt-get install indicator-sysmonitor
+    
+    Search in the dash for "indicator-sysmonitor" to run
+
+To install the Budgie Applet via PPA:
+
+    open budgie-welcome - Install Software - Budgie Applets
+
+Changelog:
+ 
+ - v0.8.3 - Rework fetch thread, README updates
+ - v0.8.2 - fix budgie-desktop crash and release debian package
+ - v0.8.1 - development - support budgie-desktop
+ - v0.8.0 - development - new sensor - cputemp, ability to use and change icons via a custom script
+ - v0.7.1 - bug fix to allow non-ubuntu kernels to be used
+ - v0.7.0 - new sensors - publicip and upordown.
+ - v0.6.3 - fixed the bug when display multiple CPU cores it always display the later ones as 0%
+ - v0.6.2 - bug fix to stop crash for custom sensors
+ - v0.6.1 - fix the debian packaging
+ - v0.6 - stable release - reworked to be easier to maintain
+ - v0.5 - GTK3 & Python3 based including bug-fix to display errors on using Test button
+     together with fixing crash reports when incorrect sensor values used
+ - v0.4.6 - bug fixes for battery indicator and for spurious overwrite when adding new sensor
+ - v0.4.5 - removed indicator icon since not needed
+ - v0.4.4 - fix dependencies and corrected shown indicator icon
+ - v0.4.3 - fork from original author
+ 
+Credits:
+ 
+ - [24](https://github.com/fossfreedom/indicator-sysmonitor/pull/24) & [25](https://github.com/fossfreedom/indicator-sysmonitor/pull/25) SteveGuo <steveguo@outlook.com> https://github.com/SteveGuo
+ - [19](https://github.com/fossfreedom/indicator-sysmonitor/pull/19) & [37](https://github.com/fossfreedom/indicator-sysmonitor/pull/37) CPU & meminfo bug fixes Jesse Johnson https://github.com/holocronweaver
+
+----
+
+Original Author: Alex Eftimie <alex@rosedu.org>
+https://launchpad.net/indicator-sysmonitor
+
+Current fork maintainer: fossfreedom <foss.freedom@gmail.com>
+
+----

--- a/budgiesysmonitor.py
+++ b/budgiesysmonitor.py
@@ -38,6 +38,8 @@ HELP_MSG = """<span underline="single" size="x-large">{title}</span>
 • mem: {mem_desc}
 • bat<i>%d</i>: {bat_desc}
 • net: {net_desc}
+• netcomp: {netcomp_desc}
+• totalnet: {totalnet_desc}
 • upordown: {upordown_desc}
 • publicip: {publicip_desc}
 
@@ -55,6 +57,10 @@ CPU {{cpu}} | MEM {{mem}} | root {{fs///}}
     mem_desc=_("It shows the physical memory in use."),
     bat_desc=_("It shows the available battery which id is %d."),
     net_desc=_("It shows the amount of data you are downloading and uploading \
+    through your network."),
+    netcomp_desc=_("It shows the amount of data you are downloading and uploading \
+    through your network in a compact way."),
+    totalnet_desc=("It shows the total amount of data you downloaded and uploaded \
     through your network."),
     upordown_desc=_("It shows whether your internet connection is up or down \
      - the sensor is refreshed every 10 seconds."),

--- a/preferences.py
+++ b/preferences.py
@@ -365,9 +365,9 @@ class Preferences(Gtk.Dialog):
             self.sensor_mgr.check(sensor)
 
         try:
-            interval = int(self.interval_entry.get_text())
-            if interval <= 0:
-                raise ISMError(_("Interval value is not valid."))
+            interval = float(self.interval_entry.get_text())
+            if interval <1:
+                raise ISMError(_("Interval value should be greater then or equal to 1 "))
 
         except ValueError:
             raise ISMError(_("Interval value is not valid."))

--- a/sensors.py
+++ b/sensors.py
@@ -27,16 +27,16 @@ import psutil as ps
 ps_v1_api = int(ps.__version__.split('.')[0]) <= 1
 
 
-B_UNITS = ['', 'KB', 'MB', 'GB', 'TB']
+B_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB']
 cpu_load = []
 
 
-def bytes_to_human(num, suffix='B'):
-    for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
+def bytes_to_human(num):
+    for unit in B_UNITS:
         if abs(num) < 1024.0:
-            return "%3.2f %s%s" % (num, unit, suffix)
+            return "%3.2f %s" % (num, unit)
         num /= 1024.0
-    return "%.2f %s%s" % (num, 'Yi', suffix)
+    return "%.2f %s" % (num, 'YB')
 
 class ISMError(Exception):
     """General exception."""

--- a/sensors.py
+++ b/sensors.py
@@ -406,7 +406,7 @@ class CPUSensor(BaseSensor):
         if percpu:
             return cpu_load
 
-        r = 0.0;
+        r = 0.0
         for i in cpu_load:
             r += i
 

--- a/sensors.py
+++ b/sensors.py
@@ -33,9 +33,9 @@ cpu_load = []
 
 def bytes_to_human(num):
     for unit in B_UNITS:
-        if abs(num) < 1024.0:
+        if abs(num) < 1000.0:
             return "%3.2f %s" % (num, unit)
-        num /= 1024.0
+        num /= 1000.0
     return "%.2f %s" % (num, 'YB')
 
 class ISMError(Exception):


### PR DESCRIPTION
This PR is for adding that functionality of floats in intervals, also it will not impact performance cause anyone cannot enter value less than 1 sec(< 1 sec was causing the real performance issue).

Second thing I added was Compact net Speed which basically is UP+DOWN and Total net speed with sigma in front of it which basically is TOTAL UP+TOTAL DOWN, which will help users to track their download and upload speed more effectively. Below is the preview in ubuntu budgie   
![image](https://user-images.githubusercontent.com/41370460/98230824-9cfcfd80-1f81-11eb-9a68-2ac6e1c8adb9.png)

IMO MiB and GiB looks ugly so if you can simply rename them to MB or GB that can be good but again its personal opinion , I have included this in this PR. I have also changed conversion rate from 1MiB=1024 KiB to 1MB = 1024KB