### PR TITLE
extend to 2/4 GPUs

### DIFF
--- a/sensors.py
+++ b/sensors.py
@@ -349,6 +349,7 @@ class NvGPUSensor(BaseSensor):
     def get_value(self, sensor):
         if sensor == 'nvgpu':
             perc = self._fetch_gpu()
+            # fell free to customize the following code for your multi-gpu machine
             if len(perc) == 1:
                 return "{:02.0f}%".format(int(perc[0][:-2]))
             elif len(perc) == 2:
@@ -374,6 +375,7 @@ class NvGPUTemp(BaseSensor):
     def get_value(self, sensor):
         # degrees symbol is unicode U+00B0
         perc = self._fetch_gputemp()
+        # fell free to customize the following code for your multi-gpu machine
         if len(perc) == 1:
             return "{}\u00B0C".format(int(perc[0]))
         elif len(perc) == 2:


### PR DESCRIPTION
I have extended the GPU function to a multi-GPU version with a simple trick. Successfully tested on a 2-GPU machine and a 4-GPU machine.
The multi-GPU output  on a 2-GPU machine is as follows:

> CPU {cpu} {cputemp} | GPU {nvgpu} {nvgputemp} | Mem {mem} | SWAP {swap} | Net {netcomp}


![2023-01-08_17-54](https://user-images.githubusercontent.com/93782452/211203132-544dca92-72a6-4ae0-8b55-b4b95df490f2.png)
