### PR TITLE
fix KeyError: 'nvgputemp',resolves #132

### DIFF
--- a/sensors.py
+++ b/sensors.py
@@ -109,7 +109,7 @@ class SensorManager(object):
             """
 
             for sensor in self.sensor_instances:
-                if sensor.check(name) is not None:
+                if sensor.check(name):
                     return sensor
 
             return None


### PR DESCRIPTION
The `CPUTemp().check` method returns `False` instead of `None` when the parameter is not the string 'cputemp', which causes an exception to occur.